### PR TITLE
add prevent-tfe-provider-workspace-deletion policy

### DIFF
--- a/cloud-agnostic/prevent-tfe-provider-workspace-deletion.sentinel
+++ b/cloud-agnostic/prevent-tfe-provider-workspace-deletion.sentinel
@@ -1,9 +1,15 @@
+# This policy uses the Sentinel tfplan/v2 import to validate that no terraform
+# cloud/enterprise workspaces are deleted with the tfe provider.
+
+# Import the tfplan/v2 import, but use the alias "tfplan"
 import "tfplan/v2" as tfplan
 
+# Get all Workspaces
 workspaces = filter tfplan.resource_changes as address, rc {
   rc.type is "tfe_workspace"
 }
 
+# Main rule
 main = rule {
   all workspaces as address, ws {
     ws.change.actions is not ["delete"]

--- a/cloud-agnostic/prevent-tfe-provider-workspace-deletion.sentinel
+++ b/cloud-agnostic/prevent-tfe-provider-workspace-deletion.sentinel
@@ -1,0 +1,11 @@
+import "tfplan/v2" as tfplan
+
+workspaces = filter tfplan.resource_changes as address, rc {
+  rc.type is "tfe_workspace"
+}
+
+main = rule {
+  all workspaces as address, ws {
+    ws.change.actions is not ["delete"]
+  }
+}

--- a/cloud-agnostic/test/prevent-tfe-provider-workspace-deletion/fail.hcl
+++ b/cloud-agnostic/test/prevent-tfe-provider-workspace-deletion/fail.hcl
@@ -1,0 +1,11 @@
+mock "tfplan/v2" {
+  module {
+    source = "mock-tfplan-v2-fail.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/cloud-agnostic/test/prevent-tfe-provider-workspace-deletion/mock-tfplan-v2-fail.sentinel
+++ b/cloud-agnostic/test/prevent-tfe-provider-workspace-deletion/mock-tfplan-v2-fail.sentinel
@@ -1,0 +1,178 @@
+terraform_version = "1.1.7"
+
+planned_values = {
+	"outputs":   {},
+	"resources": {},
+}
+
+variables = {}
+
+resource_changes = {
+	"tfe_workspace.production": {
+		"address": "tfe_workspace.production",
+		"change": {
+			"actions": [
+				"delete",
+			],
+			"after":         null,
+			"after_unknown": {},
+			"before": {
+				"agent_pool_id":         "",
+				"allow_destroy_plan":    true,
+				"auto_apply":            false,
+				"description":           "",
+				"execution_mode":        "remote",
+				"file_triggers_enabled": true,
+				"global_remote_state":   false,
+				"id":                            "ws-Xr62gkMwt9fuzBP8",
+				"name":                          "production",
+				"operations":                    true,
+				"organization":                  "hashidemos",
+				"queue_all_runs":                true,
+				"remote_state_consumer_ids":     [],
+				"speculative_enabled":           true,
+				"ssh_key_id":                    "",
+				"structured_run_output_enabled": true,
+				"tag_names":                     [],
+				"terraform_version":             "latest",
+				"trigger_prefixes":              [],
+				"vcs_repo":                      [],
+				"working_directory":             "",
+			},
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "production",
+		"provider_name":  "registry.terraform.io/hashicorp/tfe",
+		"type":           "tfe_workspace",
+	},
+}
+
+output_changes = {}
+
+raw = {
+	"configuration": {
+		"root_module": {
+			"resources": [
+				{
+					"address": "tfe_workspace.production",
+					"expressions": {
+						"name": {
+							"constant_value": "production",
+						},
+						"organization": {
+							"constant_value": "hashidemos",
+						},
+						"terraform_version": {
+							"constant_value": "latest",
+						},
+					},
+					"mode":                "managed",
+					"name":                "production",
+					"provider_config_key": "tfe",
+					"schema_version":      1,
+					"type":                "tfe_workspace",
+				},
+			],
+		},
+	},
+	"format_version": "1.0",
+	"planned_values": {
+		"root_module": {},
+	},
+	"prior_state": {
+		"format_version":    "1.0",
+		"terraform_version": "1.1.7",
+		"values": {
+			"root_module": {
+				"resources": [
+					{
+						"address":        "tfe_workspace.production",
+						"mode":           "managed",
+						"name":           "production",
+						"provider_name":  "registry.terraform.io/hashicorp/tfe",
+						"schema_version": 1,
+						"sensitive_values": {
+							"remote_state_consumer_ids": [],
+							"tag_names":                 [],
+							"trigger_prefixes":          [],
+							"vcs_repo":                  [],
+						},
+						"type": "tfe_workspace",
+						"values": {
+							"agent_pool_id":         "",
+							"allow_destroy_plan":    true,
+							"auto_apply":            false,
+							"description":           "",
+							"execution_mode":        "remote",
+							"file_triggers_enabled": true,
+							"global_remote_state":   false,
+							"id":                            "ws-Xr62gkMwt9fuzBP8",
+							"name":                          "production",
+							"operations":                    true,
+							"organization":                  "hashidemos",
+							"queue_all_runs":                true,
+							"remote_state_consumer_ids":     [],
+							"speculative_enabled":           true,
+							"ssh_key_id":                    "",
+							"structured_run_output_enabled": true,
+							"tag_names":                     [],
+							"terraform_version":             "latest",
+							"trigger_prefixes":              [],
+							"vcs_repo":                      [],
+							"working_directory":             "",
+						},
+					},
+				],
+			},
+		},
+	},
+	"resource_changes": [
+		{
+			"address": "tfe_workspace.production",
+			"change": {
+				"actions": [
+					"delete",
+				],
+				"after_sensitive": false,
+				"after_unknown":   {},
+				"before": {
+					"agent_pool_id":         "",
+					"allow_destroy_plan":    true,
+					"auto_apply":            false,
+					"description":           "",
+					"execution_mode":        "remote",
+					"file_triggers_enabled": true,
+					"global_remote_state":   false,
+					"id":                            "ws-Xr62gkMwt9fuzBP8",
+					"name":                          "production",
+					"operations":                    true,
+					"organization":                  "hashidemos",
+					"queue_all_runs":                true,
+					"remote_state_consumer_ids":     [],
+					"speculative_enabled":           true,
+					"ssh_key_id":                    "",
+					"structured_run_output_enabled": true,
+					"tag_names":                     [],
+					"terraform_version":             "latest",
+					"trigger_prefixes":              [],
+					"vcs_repo":                      [],
+					"working_directory":             "",
+				},
+				"before_sensitive": {
+					"remote_state_consumer_ids": [],
+					"tag_names":                 [],
+					"trigger_prefixes":          [],
+					"vcs_repo":                  [],
+				},
+			},
+			"mode":          "managed",
+			"name":          "production",
+			"provider_name": "registry.terraform.io/hashicorp/tfe",
+			"type":          "tfe_workspace",
+		},
+	],
+	"terraform_version": "1.1.7",
+}

--- a/cloud-agnostic/test/prevent-tfe-provider-workspace-deletion/mock-tfplan-v2-pass.sentinel
+++ b/cloud-agnostic/test/prevent-tfe-provider-workspace-deletion/mock-tfplan-v2-pass.sentinel
@@ -1,0 +1,198 @@
+terraform_version = "1.1.7"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"tfe_workspace.production": {
+			"address":        "tfe_workspace.production",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "production",
+			"provider_name":  "registry.terraform.io/hashicorp/tfe",
+			"tainted":        false,
+			"type":           "tfe_workspace",
+			"values": {
+				"agent_pool_id":                 null,
+				"allow_destroy_plan":            true,
+				"auto_apply":                    false,
+				"description":                   null,
+				"file_triggers_enabled":         true,
+				"name":                          "production",
+				"organization":                  "hashidemos",
+				"queue_all_runs":                true,
+				"speculative_enabled":           true,
+				"ssh_key_id":                    null,
+				"structured_run_output_enabled": true,
+				"terraform_version":             "latest",
+				"vcs_repo":                      [],
+				"working_directory":             null,
+			},
+		},
+	},
+}
+
+variables = {}
+
+resource_changes = {
+	"tfe_workspace.production": {
+		"address": "tfe_workspace.production",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"agent_pool_id":                 null,
+				"allow_destroy_plan":            true,
+				"auto_apply":                    false,
+				"description":                   null,
+				"file_triggers_enabled":         true,
+				"name":                          "production",
+				"organization":                  "hashidemos",
+				"queue_all_runs":                true,
+				"speculative_enabled":           true,
+				"ssh_key_id":                    null,
+				"structured_run_output_enabled": true,
+				"terraform_version":             "latest",
+				"vcs_repo":                      [],
+				"working_directory":             null,
+			},
+			"after_unknown": {
+				"execution_mode":      true,
+				"global_remote_state": true,
+				"id":                        true,
+				"operations":                true,
+				"remote_state_consumer_ids": true,
+				"tag_names":                 true,
+				"trigger_prefixes":          true,
+				"vcs_repo":                  [],
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "production",
+		"provider_name":  "registry.terraform.io/hashicorp/tfe",
+		"type":           "tfe_workspace",
+	},
+}
+
+output_changes = {}
+
+raw = {
+	"configuration": {
+		"root_module": {
+			"resources": [
+				{
+					"address": "tfe_workspace.production",
+					"expressions": {
+						"name": {
+							"constant_value": "production",
+						},
+						"organization": {
+							"constant_value": "hashidemos",
+						},
+						"terraform_version": {
+							"constant_value": "latest",
+						},
+					},
+					"mode":                "managed",
+					"name":                "production",
+					"provider_config_key": "tfe",
+					"schema_version":      1,
+					"type":                "tfe_workspace",
+				},
+			],
+		},
+	},
+	"format_version": "1.0",
+	"planned_values": {
+		"root_module": {
+			"resources": [
+				{
+					"address":        "tfe_workspace.production",
+					"mode":           "managed",
+					"name":           "production",
+					"provider_name":  "registry.terraform.io/hashicorp/tfe",
+					"schema_version": 1,
+					"sensitive_values": {
+						"remote_state_consumer_ids": [],
+						"tag_names":                 [],
+						"trigger_prefixes":          [],
+						"vcs_repo":                  [],
+					},
+					"type": "tfe_workspace",
+					"values": {
+						"agent_pool_id":                 null,
+						"allow_destroy_plan":            true,
+						"auto_apply":                    false,
+						"description":                   null,
+						"file_triggers_enabled":         true,
+						"name":                          "production",
+						"organization":                  "hashidemos",
+						"queue_all_runs":                true,
+						"speculative_enabled":           true,
+						"ssh_key_id":                    null,
+						"structured_run_output_enabled": true,
+						"terraform_version":             "latest",
+						"vcs_repo":                      [],
+						"working_directory":             null,
+					},
+				},
+			],
+		},
+	},
+	"resource_changes": [
+		{
+			"address": "tfe_workspace.production",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"agent_pool_id":                 null,
+					"allow_destroy_plan":            true,
+					"auto_apply":                    false,
+					"description":                   null,
+					"file_triggers_enabled":         true,
+					"name":                          "production",
+					"organization":                  "hashidemos",
+					"queue_all_runs":                true,
+					"speculative_enabled":           true,
+					"ssh_key_id":                    null,
+					"structured_run_output_enabled": true,
+					"terraform_version":             "latest",
+					"vcs_repo":                      [],
+					"working_directory":             null,
+				},
+				"after_sensitive": {
+					"remote_state_consumer_ids": [],
+					"tag_names":                 [],
+					"trigger_prefixes":          [],
+					"vcs_repo":                  [],
+				},
+				"after_unknown": {
+					"execution_mode":      true,
+					"global_remote_state": true,
+					"id":                        true,
+					"operations":                true,
+					"remote_state_consumer_ids": true,
+					"tag_names":                 true,
+					"trigger_prefixes":          true,
+					"vcs_repo":                  [],
+				},
+				"before":           null,
+				"before_sensitive": false,
+			},
+			"mode":          "managed",
+			"name":          "production",
+			"provider_name": "registry.terraform.io/hashicorp/tfe",
+			"type":          "tfe_workspace",
+		},
+	],
+	"terraform_version": "1.1.7",
+}

--- a/cloud-agnostic/test/prevent-tfe-provider-workspace-deletion/pass.hcl
+++ b/cloud-agnostic/test/prevent-tfe-provider-workspace-deletion/pass.hcl
@@ -1,0 +1,11 @@
+mock "tfplan/v2" {
+  module {
+    source = "mock-tfplan-v2-pass.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = true
+  }
+}


### PR DESCRIPTION
this policy can be used to prevent deletion of workspaces with the tfe provider
credit to [John Weigand](https://www.datocms-assets.com/2885/1635524145-hctrimblecasestudyweb.pdf), Senior DevOps Engineer at Trimble