### PR TITLE
make allowed_regions a configurable param

### DIFF
--- a/aws/validate-providers-from-desired-regions.sentinel
+++ b/aws/validate-providers-from-desired-regions.sentinel
@@ -23,7 +23,7 @@ import "strings"
 import "aws-functions" as aws
 
 # Allowed AWS regions
-allowed_regions = ["us-east-1", "us-west-1"]
+param allowed_regions default ["us-east-1", "us-west-1"]
 
 # Get all AWS providers
 all_aws_providers = config.find_providers_by_type("aws")


### PR DESCRIPTION
The title says it all: make `allowed_regions` a configurable parameter. This way I can actually configure the regions, I need:

![CleanShot 2022-06-24 at 16 54 43@2x](https://user-images.githubusercontent.com/16440184/175561704-49948ca6-a347-468e-9a71-f0f46e7e4e8b.png)
