### PR TITLE
Add initial note of migration work

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Example Third Generation Sentinel Policies for Terraform
+
+NOTE: The content of this repository is in the process of being migrated to the [Terraform Registry](https://registry.terraform.io/browse/policies).
+
 This directory and its sub-directories contain third-generation Sentinel policies and associated [Sentinel CLI](https://docs.hashicorp.com/sentinel/intro/getting-started/install) test cases and mocks which were created in 2020 for AWS, Microsoft Azure, Google Cloud Platform (GCP), and VMware. It also contains some some common, re-usable functions.
 
 Additionally, it contains [Policy Set](https://www.terraform.io/docs/cloud/sentinel/manage-policies.html#the-sentinel-hcl-configuration-file) configuration files so that the cloud-specific and cloud-agnostic policies can easily be added to Terraform Cloud organizations using [VCS Integrations](https://www.terraform.io/docs/cloud/vcs/index.html) after forking this repository.


### PR DESCRIPTION
Possibly an over-enthusiastic branch name, but safety first.  This marks the beginning of the migration of the Sentinel policies from this repo into the Terraform Reg in agreement with @hcrhall.