### PR TITLE
Remove resources that have no after values

### DIFF
--- a/azure/azure-functions/azure-functions.sentinel
+++ b/azure/azure-functions/azure-functions.sentinel
@@ -12,7 +12,8 @@ find_resources_with_standard_tags = func(resource_types) {
     rc.type in resource_types and
   	rc.mode is "managed" and
   	(rc.change.actions contains "create" or rc.change.actions contains "update" or
-     rc.change.actions contains "read" or rc.change.actions contains "no-op")
+     rc.change.actions contains "read" or (rc.change.actions contains "no-op" and
+     rc.change.after is not null))
   }
 
   return resources


### PR DESCRIPTION
Based on the description of [find_resources_with_standard_tags](https://github.com/hashicorp/terraform-sentinel-policies/blob/b87c3c59e296aba80cdb670f059ffa55429a774d/azure/azure-functions/docs/find_resources_with_standard_tags.md?plain=1#L2) the function should only return Azure resource instances that are not being permanently deleted. The same code is already existing in [common-functions/tfplan-functions/find_resources](https://github.com/hashicorp/terraform-sentinel-policies/blob/b87c3c59e296aba80cdb670f059ffa55429a774d/common-functions/tfplan-functions/tfplan-functions.sentinel#L30)