### PR TITLE
Enhancement to better handle long message formats.

### DIFF
--- a/common-functions/report/report.sentinel
+++ b/common-functions/report/report.sentinel
@@ -22,9 +22,10 @@ down_arrow = "\u21b3"
 
 // Strings
 root_module = "root"
+title_overview = "Overview: "
 overall_result = arrow_icon + space + arrow_icon + space + "Overall Result: "
-success_message = "This result means that all resources have passed the policy check for the policy "
-failure_message = "This result means that not all resources passed the policy check and the protected behavior is not allowed for the policy "
+success_message = "All resources have successfully passed."
+failure_message = "Not all resources passed, so the protected behavior is not allowed."
 found_zero_resource_violations = "Found 0 resource violations"
 resource_violations = "resource violations"
 module_header = "Module name: "
@@ -34,10 +35,13 @@ failed = "failed"
 generate_policy_report = func(summary) {
 
 	generate_success_summary_string = func(summary) {
-		report = green + overall_result + "true" + reset
+		report = title_overview + new_line + summary.message
 		report += new_line
 		report += new_line
-		report += success_message + summary.policy_name + dot
+		report += green + overall_result + "true" + reset
+		report += new_line
+		report += new_line
+		report += success_message
 		report += new_line
 		report += new_line
 		report += check_icon + space + found_zero_resource_violations
@@ -45,10 +49,13 @@ generate_policy_report = func(summary) {
 	}
 
 	generate_failure_summary_string = func(summary) {
-		report = red + overall_result + "false" + reset
+		report = title_overview + new_line + summary.message
 		report += new_line
 		report += new_line
-		report += failure_message + summary.policy_name + dot
+		report += red + overall_result + "false" + reset
+		report += new_line
+		report += new_line
+		report += failure_message
 		report += new_line
 		report += new_line
 		report += "Found " + string(length(summary.violations)) + space + resource_violations
@@ -66,7 +73,7 @@ generate_policy_report = func(summary) {
 				report += new_line
 				report += tab + tab + space + pipe + space + cross_icon + space + failed
 				report += new_line
-				report += tab + tab + space + pipe + space + v.message
+				report += tab + tab + space + pipe + space + v.action
 				report += new_line
 			}
 		}

--- a/common-functions/report/testing/test/test_report/fail.hcl
+++ b/common-functions/report/testing/test/test_report/fail.hcl
@@ -1,0 +1,18 @@
+global "violations" {
+  value = {
+    resources = {
+      foo = {
+        address        = "foo.this"
+        module_address = ""
+      }
+      bar = {
+        address        = "module.foo.bar.this"
+        module_address = "module.foo"
+      }
+    }
+  }
+}
+
+import "module" "report" {
+  source = "../../../report.sentinel"
+}

--- a/common-functions/report/testing/test/test_report/pass.hcl
+++ b/common-functions/report/testing/test/test_report/pass.hcl
@@ -1,0 +1,9 @@
+global "violations" {
+  value = {
+    resources = {}
+  }
+}
+
+import "module" "report" {
+  source = "../../../report.sentinel"
+}

--- a/common-functions/report/testing/test_report.sentinel
+++ b/common-functions/report/testing/test_report.sentinel
@@ -1,0 +1,29 @@
+import "report"
+
+const = {
+	"policy_name": "test_report",
+	"message": "In order to comply with this control all values should be set to 'bar'. For more information, visit https://choosebar.com.",
+	"action": "Set value to 'bar'",
+}
+
+summary = {
+	"policy_name": const.policy_name,
+	"message": const.message,
+	"violations": map violations.resources as _, v {
+		{
+			"address":        v.address,
+			"module_address": v.module_address,
+			"action":        const.action,
+		}
+	},
+}
+
+# Outputs
+
+print(report.generate_policy_report(summary))
+
+# Rules
+
+main = rule {
+	true
+}


### PR DESCRIPTION
PR includes tests for the `report.sentinel` module as well as a few amendments to the format that will hopefully improve the way in which we share long form messages with users.

Changes include:
- Moved the violation message into a new section at the top of print statement called  "Overview:"
- Expanded the violation map to include a new value call action which is used to provide a succinct call to action.

**Output:** 
![image](https://github.com/hashicorp/terraform-sentinel-policies/assets/36720823/14cda998-71a1-41f2-afc6-2ae4e51f0706)
